### PR TITLE
Added .secure so it wont be pushed to public repo for others to take…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 .vscode
 .idea/
+.secure/
+.secure/.apikeys.js
 .DS_Store
 ._.DS_Store
 **/.DS_Store

--- a/assets/javascript/fav.js
+++ b/assets/javascript/fav.js
@@ -20,7 +20,7 @@
 
 // Initialize Firebase
 var config = {
-    apiKey: "AIzaSyC1rPD9yqt2-9mk-T2WEwmFAc4uzYYr1UI",
+    apiKey: PAUL_FBWEATHER_APIKEY,
     authDomain: "weatherdashboard-47786.firebaseapp.com",
     databaseURL: "https://weatherdashboard-47786.firebaseio.com",
     projectId: "weatherdashboard-47786",

--- a/favoriteCities.html
+++ b/favoriteCities.html
@@ -95,6 +95,7 @@
 
     </main>
 
+    <script type="text/javascript" src=".secure/.apikeys.js"></script>
     <script type="text/javascript" src="assets/javascript/fav.js"></script>
     </script>
 


### PR DESCRIPTION
I updated the .gitignore file so that anything in the .secure directory will NOT be pushed up to the repository.  This is where we can store our APIKEYs or other information that should not be pushed to our public GitHub repository.  Currently, I have a file called .secure/.apikeys.js that has the APIKeys that I have created.  That file will need to be included anywhere these APIKEYs are used but it should never be pushed to the repo so others can steal the keys and use up our quotas.

We will each need to maintain our own .secure/.apikeys.js file with the keys.  

I have also implemented this in the favoriteCities.html file (includes .secure/.apikeys.js) file and use the const key in the fav.js file. 

At some point we will have to figure out how to deploy this key securely but for now we dont want it to get out there for anyone to use.