### PR TITLE
Pass data back to dashboard from edit page

### DIFF
--- a/assets/javascript/favoritesDashboardController.js
+++ b/assets/javascript/favoritesDashboardController.js
@@ -28,6 +28,33 @@ function favoritesDropdwnRender(favorites) {
     }
 }
 
+function currentFavoriteHandler(key) {
+    favoriteGet(key, function (favoriteFB) {
+        console.log(favoriteFB);
+
+        // do not try to do anything if it wasnt found
+        if (favoriteFB.name != undefined) {
+            // render the name in the text field so you know
+            $("#dataPull").val(favoriteFB.name);
+
+            // get lat long from Justins API
+            // hardcode for now
+            let geoLocation = {};
+            geoLocation.lat = 33.787549;
+            geoLocation.long = -84.314085;
+
+            // geoLocation = getLatLong(favoriteFB.city);
+
+            // Call weatherAPI with lat long
+            getWeather(geoLocation.lat, geoLocation.long);
+
+            // Call places api
+            // getPlaceInfo(favoriteFB);
+        }
+
+    });
+}
+
 // Wait for doc to be ready
 $(document).ready(function () {
 
@@ -36,28 +63,12 @@ $(document).ready(function () {
 
         var key = $(this).attr("data-key");
 
-        // Show the one clicked - get it from FB
-        favoriteGet(key, function (favoriteFB) {
-            console.log(favoriteFB);
+        // save it for next time
+        saveKeyToLocalStorage(key);
 
-            // render the name in the text field so you know
-            $("#dataPull").val(favoriteFB.name);
+        // run the function that calls the DB and handles the result
+        currentFavoriteHandler(key);
 
-            // get lat long from Justins API
-            // hardcode for now
-            let geoLocation = {};
-            geoLocation.lat = 33.787549;
-            geoLocation.long =  -84.314085;
-            
-            // geoLocation = getLatLong(favoriteFB.city);
-
-            // Call weatherAPI with lat long
-            getWeather(geoLocation.lat, geoLocation.long);
-
-            // Call places api
-            // getPlaceInfo(favoriteFB);
-
-        });
     });
 
     // MAIN Start
@@ -66,6 +77,18 @@ $(document).ready(function () {
         favoritePlaces = favs; // copy the array into the global var for this context
         // render fav list
         favoritesDropdwnRender(favoritePlaces);
+
+        // check to see if there is a value in local storage
+        key = getKeyFromLocalStorage();
+
+        if (key != undefined) {
+            currentFavoriteHandler(key);
+        } else {
+            // if there are any favorites, populate the first on
+            if (favoritePlaces.length > 0) {
+                currentFavoriteHandler(favoritePlaces[0].key);
+            }
+        }
     });
 
 }); // (document).ready

--- a/assets/javascript/favoritesEditController.js
+++ b/assets/javascript/favoritesEditController.js
@@ -23,6 +23,7 @@ function favoritesRender(favorites) {
 
         if (favoritePlace.editMode) {
             newRow = $(`<tr id="${favoritePlace.key}" data-key="${favoritePlace.key}" data-index="${i}">`).append(
+                $("<td>").html(`<button class="choose-favorite" data-key="${favoritePlace.key}" data-index="${i}">Choose</button>`),
                 $("<td>").html(`<input id="${favoritePlace.key}-name" type="text" value="${favoritePlace.name}"></input>`),
                 $("<td>").html(`<input id="${favoritePlace.key}-address" type="text" value="${favoritePlace.address}"></input>`),
                 $("<td>").html(`<input id="${favoritePlace.key}-city" type="text" value="${favoritePlace.city}"></input>`),
@@ -33,6 +34,7 @@ function favoritesRender(favorites) {
             );
         } else {
             newRow = $(`<tr id="${favoritePlace.key}" data-key="${favoritePlace.key}" data-index="${i}">`).append(
+                $("<td>").html(`<button class="choose-favorite" data-key="${favoritePlace.key}" data-index="${i}">Choose</button>`),
                 $("<td>").text(`${favoritePlace.name}`),
                 $("<td>").text(`${favoritePlace.address}`),
                 $("<td>").text(`${favoritePlace.city}`),
@@ -53,11 +55,9 @@ $(document).ready(function () {
     // Add a new favorite
     $("#add-favorite-btn").on("click", function (event) {
         event.preventDefault();
-
-        // Grab user input
-
         // Validate user Input
 
+        // Grab user input
         let favoritePlace = {
             name: $("#name").val().trim(),
             address: $("#address").val().trim(),
@@ -77,8 +77,14 @@ $(document).ready(function () {
         $("#zipCode").val("");
     });
 
+    // Close and go back to favorites page
+    $(document.body).on("click", ".button-close-page", function () {
+        // switch page to dashboard
+        window.location.href = "index.html";
+    });
+
     // Select a row/favorite 
-    $(document.body).on("click", "#favorites-table-data tr", function () {
+    $(document.body).on("click", ".choose-favorite", function () {
         var index = $(this).attr("data-index");
         var key = $(this).attr("data-key");
 

--- a/assets/javascript/favoritesEditController.js
+++ b/assets/javascript/favoritesEditController.js
@@ -82,6 +82,11 @@ $(document).ready(function () {
         var index = $(this).attr("data-index");
         var key = $(this).attr("data-key");
 
+        // Save the key to local storage for use on home page to pass back to dashboard
+        saveKeyToLocalStorage(key);
+
+        // * The following lines ar e just for testing
+        // * ==============================================
         // get the one clicked from array in memory
         let favoritePlace = arrayItemGet(index);
         console.log(favoritePlace);
@@ -93,6 +98,12 @@ $(document).ready(function () {
 
         // Show the weather, places, map for this favorite
         // Go to the dashboard with the place selected
+
+        // * END TEST CODE - this is where real app code starts 
+        // * ==============================================
+
+        // switch page to dashboard
+        window.location.href = "index.html";
 
     });
 
@@ -154,7 +165,7 @@ $(document).ready(function () {
     // MAIN Start
     // Populate this list of favorite places in the database
     favoritesGet(function (favs) {
-        favoritePlaces = favs;          // copy the array into the global var for this context
+        favoritePlaces = favs; // copy the array into the global var for this context
 
         // render fav list
         favoritesRender(favoritePlaces);

--- a/assets/javascript/favoritesModel.js
+++ b/assets/javascript/favoritesModel.js
@@ -123,13 +123,23 @@ function favoritesGetByName(aCallback) {
 }
 
 /*
- * In memory data managment 
- * These are the functions that manage the data stored in memory in the array
- * The database stores the persistent data.  The in memory array holds all that database data
- * plus other trasient and calculated data.  That in memory data is used by the view controller
- * to render the data on the pages.  Its a feeble attempt at MVC separation of responsibilites
+ * Local Storage Management
+ * These are used to store and retrieve things from local storage
+ * The main thing this is used for is to pass data from the pages within out application
  * ====================================================================================================
  */
+
+// save last one for later retrieval
+function saveKeyToLocalStorage(key) {
+    localStorage.setItem("favoriteKey", key);
+}
+
+// get whatever is in local storage for later retrieval
+function getKeyFromLocalStorage() {
+    return localStorage.getItem("favoriteKey");
+}
+
+
 
 // remove a favorite from the array based on key
 function arrayItemRemove(favorites, index) {

--- a/favoritePlaces.html
+++ b/favoritePlaces.html
@@ -39,75 +39,86 @@
 
 <body>
     <!-- Jumbotron -->
-    <div class="jumbotron jumbotron-fluid" style="background: none; color: black">
+    <!-- <div class="jumbotron jumbotron-fluid" style="background: none; color: black">
         <h1 class="text-center">Update Favorite Travel Desintations</h1>
         <h3 class="text-center">Save your favorites here</h3>
-    </div>
+    </div> -->
 
     <!-- Main Section -->
-    <div class="container-fluid">
-        <div class="col-md-12">
-            <!-- Favorites -->
+    <main class="container p-5">
+        <div class="container-fluid">
             <div class="card">
-                <div class="card-header font-italic text-info">
-                    Current Favorites - Click anywhere on a row to select that favorite and go to dashboard>
+                <div class="card-header font-weight-bold text-uppercase">
+                    Favorites Update<small class="float-right">
+                        <button type="button" class="button-close-page close" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </small>
                 </div>
-                <div class="card-body">
-                    <div class="container-fluid">
-                        <table class="table table-responsive table-hover table-striped w-auto" id='favorites-table'>
-                            <thead>
-                                <tr>
-                                    <th>Name</th>
-                                    <th>Address</th>
-                                    <th>City</th>
-                                    <th>State</th>
-                                    <th>Zip Code</th>
-                                    <th>Delete</th>
-                                    <th>Edit</th>
-                                </tr>
-                            </thead>
-                            <tbody id="favorites-table-data">
-                            </tbody>
-                        </table>
+
+                <!-- Favorites -->
+                <div class="card m-2">
+                    <div class="card-header font-italic text-info">
+                        Current Favorites - (select 'choose' if you wish to go to dashboard passing that favorite)
+                    </div>
+                    <div class="card-body">
+                        <div class="container-fluid">
+                            <table class="table table-responsive table-hover table-striped w-auto" id='favorites-table'>
+                                <thead>
+                                    <tr>
+                                        <th>Choose</th>
+                                        <th>Name</th>
+                                        <th>Address</th>
+                                        <th>City</th>
+                                        <th>State</th>
+                                        <th>Zip Code</th>
+                                        <th>Delete</th>
+                                        <th>Edit</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="favorites-table-data">
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <!-- </div> -->
+                <div class="card m-2">
+                    <div class="card-header">
+                        Add Favorite
+                    </div>
+                    <div class="card-body">
+                        <!-- Entry Form -->
+                        <form class="form-input">
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input id="name" placeholder="Hilton Back Bay" type="text">
+                            </div>
+                            <div class="form-group">
+                                <label for="address">Address</label>
+                                <input id="address" placeholder="40 Dalton St" type="text">
+                            </div>
+                            <div class="form-group">
+                                <label for="city">City</label>
+                                <input id="city" placeholder="Boston" type="text">
+                            </div>
+                            <div class="form-group">
+                                <label for="state">State</label>
+                                <input id="state" placeholder="MA" type="text">
+                            </div>
+                            <div class="form-group">
+                                <label for="zipCode">Zip Code</label>
+                                <input id="zipCode" placeholder="02115" type="text">
+                            </div>
+                            <button class="submit btn btn-primary float-left mx-4" id="add-favorite-btn" value="Submit">Submit</button>
+                            <button class="reset btn btn-primary float-left mx-4" type="reset" value="Clear">Clear</button>
+                            <button type="button" class="button-close-page btn btn-success float-right mx-4">Close</button>
+                        </form>
                     </div>
                 </div>
             </div>
         </div>
-        <!-- Add Favorite Destination  -->
-        <div class="card mt-2">
-            <div class="card-header">
-                Add Favorite
-            </div>
-            <div class="card-body">
-                <!-- Entry Form -->
-                <form class="form-input">
-                    <div class="form-group">
-                        <label for="name">Name</label>
-                        <input id="name" placeholder="Hilton Back Bay" type="text">
-                    </div>
-                    <div class="form-group">
-                        <label for="address">Address</label>
-                        <input id="address" placeholder="40 Dalton St" type="text">
-                    </div>
-                    <div class="form-group">
-                        <label for="city">City</label>
-                        <input id="city" placeholder="Boston" type="text">
-                    </div>
-                    <div class="form-group">
-                        <label for="state">State</label>
-                        <input id="state" placeholder="MA" type="text">
-                    </div>
-                    <div class="form-group">
-                        <label for="zipCode">Zip Code</label>
-                        <input id="zipCode" placeholder="02115" type="text">
-                    </div>
-                    <button class="submit btn btn-primary float-left mx-4" id="add-favorite-btn" value="Submit">Submit</button>
-                    <button class="reset btn btn-primary float-left mx-4" type="reset" value="Clear">Clear</button>
-                </form>
-            </div>
-        </div>
-    </div>
-    </div>
+    </main>
 
     <script type="text/javascript" src="assets/javascript/favoritesModel.js"></script>
     <script type="text/javascript" src="assets/javascript/favoritesEditController.js"></script>

--- a/favoritePlaces.html
+++ b/favoritePlaces.html
@@ -49,13 +49,12 @@
         <div class="col-md-12">
             <!-- Favorites -->
             <div class="card">
-                <div class="card-header">
-                    Current Favorites
+                <div class="card-header font-italic text-info">
+                    Current Favorites - Click anywhere on a row to select that favorite and go to dashboard>
                 </div>
                 <div class="card-body">
                     <div class="container-fluid">
-                        <div class="table-responsive">
-                        <table class="table table-hover table-striped w-auto" id='favorites-table'>
+                        <table class="table table-responsive table-hover table-striped w-auto" id='favorites-table'>
                             <thead>
                                 <tr>
                                     <th>Name</th>
@@ -70,45 +69,44 @@
                             <tbody id="favorites-table-data">
                             </tbody>
                         </table>
-                        </div>
                     </div>
                 </div>
             </div>
+        </div>
+        <!-- Add Favorite Destination  -->
+        <div class="card mt-2">
+            <div class="card-header">
+                Add Favorite
             </div>
-            <!-- Add Favorite Destination  -->
-            <div class="card mt-2">
-                <div class="card-header">
-                    Add Favorite
-                </div>
-                <div class="card-body">
-                    <!-- Entry Form -->
-                    <form class="form-input">
-                        <div class="form-group">
-                            <label for="name">Name</label>
-                            <input id="name" placeholder="Hilton Back Bay" type="text">
-                        </div>
-                        <div class="form-group">
-                            <label for="address">Address</label>
-                            <input id="address" placeholder="40 Dalton St" type="text">
-                        </div>
-                        <div class="form-group">
-                            <label for="city">City</label>
-                            <input id="city" placeholder="Boston" type="text">
-                        </div>
-                        <div class="form-group">
-                            <label for="state">State</label>
-                            <input id="state" placeholder="MA" type="text">
-                        </div>
-                        <div class="form-group">
-                            <label for="zipCode">Zip Code</label>
-                            <input id="zipCode" placeholder="02115" type="text">
-                        </div>
-                        <button class="submit btn btn-primary float-left mx-4" id="add-favorite-btn" value="Submit">Submit</button>
-                        <button class="reset btn btn-primary float-left mx-4" type="reset" value="Clear">Clear</button>
-                    </form>
-                </div>
+            <div class="card-body">
+                <!-- Entry Form -->
+                <form class="form-input">
+                    <div class="form-group">
+                        <label for="name">Name</label>
+                        <input id="name" placeholder="Hilton Back Bay" type="text">
+                    </div>
+                    <div class="form-group">
+                        <label for="address">Address</label>
+                        <input id="address" placeholder="40 Dalton St" type="text">
+                    </div>
+                    <div class="form-group">
+                        <label for="city">City</label>
+                        <input id="city" placeholder="Boston" type="text">
+                    </div>
+                    <div class="form-group">
+                        <label for="state">State</label>
+                        <input id="state" placeholder="MA" type="text">
+                    </div>
+                    <div class="form-group">
+                        <label for="zipCode">Zip Code</label>
+                        <input id="zipCode" placeholder="02115" type="text">
+                    </div>
+                    <button class="submit btn btn-primary float-left mx-4" id="add-favorite-btn" value="Submit">Submit</button>
+                    <button class="reset btn btn-primary float-left mx-4" type="reset" value="Clear">Clear</button>
+                </form>
             </div>
         </div>
+    </div>
     </div>
 
     <script type="text/javascript" src="assets/javascript/favoritesModel.js"></script>


### PR DESCRIPTION
 updated the pages to pass data between the index.html page and the edit controller and page.
1. Every time a favorite is selected, I store in in local storage to be used later
2. when page loads I get last fav used from local storage and use that as the selected location for calling weather and places services
3. when a user selects a favorite on the EDIT page, I store that favorite and pass it to the dashboard page.

So switching bewteen pages works. But I still would like to add a *close* button to the card so that it will just jump back and leave the storage alone. That is next commit

1.) Added a close icon in top right corner of page to go back to the dashbopard page
2.) added close button in lower right of page to go back to dashboard page
3.) added 'choose' button to each favorite which allows you to choose that favorita and pass it back to the dashboard